### PR TITLE
Fix: semicolon placed after a single- or doublequote

### DIFF
--- a/src/parser/parser_cases.c
+++ b/src/parser/parser_cases.c
@@ -6,7 +6,7 @@
 /*   By: aaugusti <aaugusti@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/03/31 13:58:24 by aaugusti      #+#    #+#                 */
-/*   Updated: 2020/04/28 17:21:14 by vtenneke      ########   odam.nl         */
+/*   Updated: 2020/08/18 15:41:02 by aaugusti      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,8 +86,10 @@ bool	parser_case_semicolon(t_mshell *mshell, t_parser *parser, char c)
 {
 	if (parser->in_squote || parser->in_dquote)
 		parser_push(mshell, parser, c);
-	else if (parser->in_word) {
-		parser->end_word = true;
+	else
+	{
+		if (parser->in_word)
+			parser->end_word = true;
 		parser->new_cmd = true;
 	}
 	return (false);


### PR DESCRIPTION
The flag `parser->new_cmd` was not always set when a semicolon is encountered. This is fixed.